### PR TITLE
fix(ci): pr size script when no label is set

### DIFF
--- a/.github/scripts/pull_request_size_label.sh
+++ b/.github/scripts/pull_request_size_label.sh
@@ -14,9 +14,15 @@ read -a rawData <<< $rawData
 
 additions=${rawData[0]}
 deletions=${rawData[1]}
-labels=${rawData[@]:2}
-current_size_label=$(echo $labels | grep -o 'Size: [^] ]*')
 pullRequestSize=$(((additions + deletions) / 2))
+
+labels=${rawData[@]:2}
+current_size_label=""
+
+if [ "$labels" != "[]" ]; then
+  current_size_label=$(echo $labels | grep -o 'Size: [^] ]*')
+fi
+
 if [ $pullRequestSize -lt 25 ]; then
   expected_label='Size: Small'
 elif [ $pullRequestSize -lt 100 ]; then


### PR DESCRIPTION
## :book: Description

<!--
  Describe your changes in detail.
-->

The PR sizing script isn't working when no label is set on the PR.

## :ticket: Related Issue(s)

<!--
  Mention Issues related to this Pull Request with the following format:
  Fixes: #1, #2, ... and #N.

  Delete this section if not needed.
-->

Fixes #43

## :clipboard: Checklist

<!--
To be merged, your Pull Request must pass all the following checks.
-->

- [x] I have added the right labels to this Pull Request
- [x] I have performed a self-review of my code
