### PR TITLE
fix(docker): postgres container healthcheck command

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -53,8 +53,8 @@ services:
     env_file:
       - ./apps/server/.env
     healthcheck:
-      test: ['CMD-SHELL', 'pg_isready', '-d', 'osu-tournament-manager']
-      interval: 250ms
+      test: ['CMD-SHELL', 'pg_isready -U dev -d osu_tournament_manager']
+      interval: 1s
       timeout: 250ms
       retries: 10
     image: postgres:16.2
@@ -108,10 +108,10 @@ services:
       spec-builder:
         condition: service_started
     healthcheck:
-      test: ['CMD', 'pnpm', 'healthcheck']
       interval: 250ms
-      timeout: 500ms
       retries: 10
+      test: ['CMD', 'pnpm', 'healthcheck']
+      timeout: 1s
     networks:
       - web
     ports:


### PR DESCRIPTION
## :book: Description

<!--
  Describe your changes in detail.
-->

The healthcheck command of `postgres` container is missing an user as parameter of `pg_isready`. Providing no user end up using the current OS user as this parameter hence the observed log since container is using `root` user.

## :ticket: Related Issue(s)

<!--
  Mention Issues related to this Pull Request with the following format:
  Fixes: #1, #2, ... and #N.

  Delete this section if not needed.
-->

Fixes #47 

## :clipboard: Checklist

<!--
To be merged, your Pull Request must pass all the following checks.
-->

- [x] I have added the right labels to this Pull Request
- [x] I have performed a self-review of my code
