### PR TITLE
refactor(apps/client): use mobile-first approach

### DIFF
--- a/apps/client/src/components/base/drawer.base.vue
+++ b/apps/client/src/components/base/drawer.base.vue
@@ -24,7 +24,7 @@
       <div>
         <slot name="header"> </slot>
       </div>
-      <div class="mb-4 flex-1 overflow-auto">
+      <div class="mb-4 flex min-h-0 flex-1 flex-col overflow-auto">
         <slot name="body"> </slot>
       </div>
       <div>
@@ -95,7 +95,8 @@ usePopUpBehavior({
 }
 
 .right {
-  @apply top-4 right-4 h-[calc(100%-32px)] w-1/2;
+  @apply top-4 right-4 h-[calc(100%-32px)] w-[calc(100%-32px)];
+  @apply sm:w-3/4 lg:w-1/2;
 }
 
 .bottom {

--- a/apps/client/src/components/base/modal.base.vue
+++ b/apps/client/src/components/base/modal.base.vue
@@ -1,15 +1,7 @@
 <template>
   <Transition name="modal">
-    <div
-      v-show="isModalOpen"
-      class="fixed inset-0 z-11 flex items-center justify-center bg-black/50"
-    >
-      <div
-        :id
-        ref="modal"
-        class="bg-primary-4 border-primary-3 relative w-1/3 rounded-md border-2 p-4"
-        @mousedown.stop
-      >
+    <div v-show="isModalOpen" class="modal-backdrop">
+      <div :id ref="modal" class="modal" @mousedown.stop>
         <div>
           <XMarkIcon
             class="x-mark"
@@ -58,6 +50,14 @@ usePopUpBehavior({
 
 <style scoped>
 @reference '#src/assets/styles/index.css';
+
+.modal {
+  @apply bg-primary-4 border-primary-3 relative w-3/4 rounded-md border-2 p-4;
+  @apply sm:w-2/3 md:w-1/2 lg:w-1/3;
+}
+.modal-backdrop {
+  @apply fixed inset-0 z-11 flex items-center justify-center bg-black/50;
+}
 
 .modal-enter-active,
 .modal-leave-active {

--- a/apps/client/src/components/base/tabList.base.vue
+++ b/apps/client/src/components/base/tabList.base.vue
@@ -1,16 +1,18 @@
 <template>
-  <div class="tab-list">
-    <div
-      v-for="tab in tabs"
-      :id="`tab-${tab.value}`"
-      :key="tab.value"
-      :class="['tab', tab.value === selected ? 'selected' : 'not-selected']"
-      :tabindex="selected === tab.value ? -1 : 0"
-      @keydown.enter="selectTab(tab.value)"
-      @mousedown="selectTab(tab.value)"
-    >
-      <BaseIcon v-if="tab.icon" :name="tab.icon" class="h-6 w-6" />
-      <BaseHeadline variant="subtitle">{{ tab.label }}</BaseHeadline>
+  <div class="scroll-wrapper">
+    <div class="tab-list">
+      <div
+        v-for="tab in tabs"
+        :id="`tab-${tab.value}`"
+        :key="tab.value"
+        :class="['tab', tab.value === selected ? 'selected' : 'not-selected']"
+        :tabindex="selected === tab.value ? -1 : 0"
+        @keydown.enter="selectTab(tab.value)"
+        @mousedown="selectTab(tab.value)"
+      >
+        <BaseIcon v-if="tab.icon" :name="tab.icon" class="h-6 w-6" />
+        <BaseHeadline variant="subtitle">{{ tab.label }}</BaseHeadline>
+      </div>
     </div>
   </div>
 </template>
@@ -46,8 +48,15 @@ const selectTab = (value: string) => {
 <style scoped>
 @reference '#src/assets/styles/index.css';
 
+.scroll-wrapper {
+  @apply overflow-x-auto;
+
+  scrollbar-width: none;
+  scrollbar-gutter: stable;
+}
+
 .tab-list {
-  @apply border-primary-3 flex flex-row items-center border-b-2;
+  @apply border-primary-3 flex w-max min-w-full flex-row items-center border-b-2;
 }
 
 .tab {
@@ -67,6 +76,6 @@ const selectTab = (value: string) => {
 }
 
 .tab:focus-visible {
-  @apply rounded-md ring-2 ring-yellow-400 outline-hidden;
+  @apply rounded-md ring-2 ring-yellow-400 outline-hidden ring-inset;
 }
 </style>

--- a/apps/client/src/components/providers/toast.provider.vue
+++ b/apps/client/src/components/providers/toast.provider.vue
@@ -1,9 +1,5 @@
 <template>
-  <TransitionGroup
-    name="toaster"
-    tag="div"
-    class="absolute bottom-4 left-1/2 z-12 w-1/3 -translate-x-1/2 space-y-2"
-  >
+  <TransitionGroup name="toaster" tag="div" class="toaster">
     <BaseToast
       v-for="toast in toasts"
       :key="toast.id"
@@ -26,6 +22,13 @@ const { toasts } = storeToRefs(useToasterStore());
 </script>
 
 <style scoped>
+@reference '#src/assets/styles/index.css';
+
+.toaster {
+  @apply absolute bottom-4 left-1/2 z-12 w-5/6 -translate-x-1/2 space-y-2;
+  @apply sm:w-3/5 lg:w-1/2 xl:w-1/3;
+}
+
 .toaster-enter-active,
 .toaster-leave-active {
   transition: all 0.5s ease;

--- a/apps/client/src/pages/login.page.vue
+++ b/apps/client/src/pages/login.page.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="flex min-h-screen items-center justify-center">
-    <div class="border-primary-3 w-1/4 rounded-md border-2 p-8 text-center">
+    <div
+      class="border-primary-3 ] w-[calc(100%-32px)] rounded-md border-2 p-8 text-center sm:w-2/3 lg:w-1/2 xl:w-2/5 2xl:w-1/3"
+    >
       <BaseHeadline class="mb-2" variant="hero">
         {{ $t('pages.login.title') }}
       </BaseHeadline>

--- a/apps/client/src/pages/matches/components/matches.chatHistory.component.vue
+++ b/apps/client/src/pages/matches/components/matches.chatHistory.component.vue
@@ -1,5 +1,7 @@
 <template>
-  <div class="border-primary-3 mx-auto mt-4 w-3/4 rounded-md border-2">
+  <div
+    class="border-primary-3 mx-auto mt-4 w-[calc(100%-32px)] rounded-md border-2 md:w-4/5 lg:w-2/3 2xl:w-1/2"
+  >
     <div
       ref="chatHistoryDiv"
       class="chat-history-container"

--- a/apps/client/src/pages/matches/components/matches.drawer.component.vue
+++ b/apps/client/src/pages/matches/components/matches.drawer.component.vue
@@ -7,23 +7,23 @@
   >
     <template #header>
       <div
-        class="align-center mx-8 mt-8 flex flex-row items-center justify-between"
+        class="align-center mx-4 mt-8 flex flex-col md:mx-8 md:flex-row md:items-center md:justify-between"
       >
         <div>
           <BaseHeadline class="">{{ match.name }}</BaseHeadline>
         </div>
-        <div v-if="match.historyUrl">
-          <BaseBody>
+        <div v-if="match.historyUrl" class="mt-2 md:mt-0">
+          <BaseCaption>
             <BaseLink is-external :link="match.historyUrl">
               {{ $t('pages.match.drawer.linkToOfficialHistory') }}
             </BaseLink>
-          </BaseBody>
+          </BaseCaption>
         </div>
       </div>
       <BaseTabList
         id="match-drawer-tab-list"
         v-model="tab"
-        class="mx-8 mt-8"
+        class="mx-4 mt-8 md:mx-8"
         :tabs="[
           {
             label: $t('pages.match.drawer.tabs.names.status'),
@@ -49,8 +49,8 @@
       />
     </template>
     <template #body>
-      <div class="h-full p-4">
-        <div v-if="tab === 'status'" class="h-full">
+      <div class="flex h-full min-h-0 flex-col pt-4 md:px-4 md:pt-8 md:pb-4">
+        <div v-if="tab === 'status'" class="flex min-h-0 flex-col">
           <MatchLobbyStatus :send-bancho-message="sendBanchoMessage" />
         </div>
         <div
@@ -81,6 +81,7 @@ import { useRoute } from 'vue-router';
 
 import { useGetMatchStateRequest } from '#src/api/matches.api.js';
 import BaseBody from '#src/components/base/body.base.vue';
+import BaseCaption from '#src/components/base/caption.base.vue';
 import BaseDrawer from '#src/components/base/drawer.base.vue';
 import BaseHeadline from '#src/components/base/headline.base.vue';
 import BaseLink from '#src/components/base/link.base.vue';

--- a/apps/client/src/pages/matches/components/matches.lobbyStatus.component.vue
+++ b/apps/client/src/pages/matches/components/matches.lobbyStatus.component.vue
@@ -1,7 +1,9 @@
 <template>
-  <div class="h-full">
-    <div class="border-primary-3 mx-4 rounded-md border-2">
-      <div class="border-primary-3 border-b-2 px-4 py-2">
+  <div class="flex min-h-0 flex-col">
+    <div
+      class="border-primary-3 mx-4 flex min-h-0 flex-col rounded-md border-2"
+    >
+      <div class="border-primary-3 shrink-0 border-b-2 px-4 py-2">
         <div class="flex items-center justify-between">
           <BaseBody variant="base" class="text-primary-2">
             {{
@@ -24,11 +26,11 @@
           </BaseButton>
         </div>
       </div>
-      <div class="flex-1 overflow-y-auto">
+      <div class="min-h-0 overflow-y-auto">
         <div v-for="(slot, slotIndex) in match.slots" :key="slotIndex">
           <div
             :class="[
-              'border-primary-4 grid grid-cols-[0.5rem_1fr_1fr_5rem_2em] items-center',
+              'border-primary-4 grid grid-cols-[0.5rem_1fr_auto_auto] items-center gap-x-2 sm:grid-cols-[0.5rem_1fr_1fr_5rem_2em] sm:gap-2',
               {
                 'border-b-2': slotIndex < match.slots.length - 1,
                 'border-t-2': slotIndex > 0,
@@ -38,31 +40,55 @@
           >
             <div
               :class="[
-                'flex h-full overflow-hidden',
+                'row-span-2 flex h-full overflow-hidden sm:row-span-1',
                 slot.player ? 'bg-primary-1' : 'bg-primary-3/60',
                 { 'rounded-bl-sm': slotIndex === match.slots.length - 1 },
               ]"
             >
               <span>&nbsp;</span>
             </div>
-            <div class="flex items-center space-x-2">
+            <div
+              class="pointer-events-none col-start-2 row-start-1 -ml-2 flex items-center space-x-2 opacity-0 sm:hidden"
+              aria-hidden="true"
+            >
               <BaseBody class="ml-2 py-2 font-bold!">
                 <span>{{ slot.player || '\u00a0' }}</span>
               </BaseBody>
               <CrownIcon v-show="slot.isHost" class="h-6 w-6 text-yellow-400" />
             </div>
-            <div v-show="slot.player">
-              <BaseModification
-                v-for="(modification, modificationIndex) in [
-                  ...match.globalModifications,
-                  ...slot.selectedModifications,
-                ]"
-                :key="modificationIndex"
-                class="mr-1"
-                :mod="modification"
-              />
+            <div
+              :class="[
+                'col-start-2 row-start-1 -ml-2 flex items-center space-x-2',
+                {
+                  'row-span-2 sm:row-span-1':
+                    match.globalModifications.length === 0 &&
+                    slot.selectedModifications.length === 0,
+                },
+              ]"
+            >
+              <BaseBody class="ml-2 py-2 font-bold!">
+                <span>{{ slot.player || '\u00a0' }}</span>
+              </BaseBody>
+              <CrownIcon v-show="slot.isHost" class="h-6 w-6 text-yellow-400" />
             </div>
-            <div class="flex">
+            <div
+              class="scrollbar col-start-2 row-start-2 flex min-h-8 overflow-x-scroll sm:col-start-3 sm:row-start-1 sm:min-h-0"
+            >
+              <template v-if="slot.player">
+                <BaseModification
+                  v-for="(modification, modificationIndex) in [
+                    ...match.globalModifications,
+                    ...slot.selectedModifications,
+                  ]"
+                  :key="modificationIndex"
+                  class="not-last:mr-1"
+                  :mod="modification"
+                />
+              </template>
+            </div>
+            <div
+              class="col-start-3 row-span-2 flex justify-end sm:col-start-4 sm:row-span-1 sm:row-start-1"
+            >
               <BaseBadge
                 v-show="slot.isReady === true"
                 color="green"
@@ -72,7 +98,10 @@
                 {{ $t('global.words.ready') }}
               </BaseBadge>
             </div>
-            <div v-if="slot.player" class="flex">
+            <div
+              v-if="slot.player"
+              class="col-start-4 row-span-2 flex sm:col-start-5 sm:row-span-1 sm:row-start-1"
+            >
               <BaseDropdown :items="quickActionsForPlayer(slot.player)" />
             </div>
           </div>
@@ -151,3 +180,13 @@ const quickActionsForPlayer = (player: string): DropdownItem[] => {
   ];
 };
 </script>
+
+<style scoped>
+@reference '#src/assets/styles/index.css';
+
+.scrollbar {
+  scrollbar-width: auto;
+  scrollbar-gutter: stable;
+  scrollbar-color: oklch(85.2% 0.199 91.936) transparent;
+}
+</style>

--- a/apps/client/src/pages/matches/create/matches.create.page.vue
+++ b/apps/client/src/pages/matches/create/matches.create.page.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="flex min-h-screen items-center justify-center">
-    <div class="border-primary-3 w-1/4 rounded-md border-2 p-8">
+    <div
+      class="border-primary-3 w-[calc(100%-32px)] rounded-md border-2 p-8 sm:w-2/3 lg:w-1/2 xl:w-2/5 2xl:w-1/3"
+    >
       <BaseHeadline variant="hero" class="mb-8 text-center"
         >{{ $t('pages.createMatch.title') }}
       </BaseHeadline>

--- a/apps/client/src/pages/matches/match.page.vue
+++ b/apps/client/src/pages/matches/match.page.vue
@@ -12,14 +12,14 @@
     <BaseBody>{{ $t('pages.match.errors.notFound') }}</BaseBody>
   </div>
   <div v-else>
-    <div class="my-4 flex justify-center">
+    <div class="mx-4 my-4 flex justify-center">
       <BaseHeadline>{{
         $t('pages.match.title', { id: match.gameMatchId })
       }}</BaseHeadline>
     </div>
     <MatchChatHistory />
     <div
-      class="align-center mt-4 flex flex-col items-center justify-center gap-y-4"
+      class="align-center m-4 flex flex-col items-center justify-center gap-4 sm:flex-row"
     >
       <BaseButton
         id="start-match-point-button"


### PR DESCRIPTION
## :book: Description

This PR implements a mobile-first foundation to build upon. This will enable managing tournaments in a lot more settings where mobile devices are easier to use, like at LAN events.

### Changes Made

**apps/client changes:**
- **Base Components Refactoring:**
  - `drawer.base.vue`: Updated to use responsive width classes (`w-[calc(100%-32px)]` on mobile, `sm:w-3/4`, `lg:w-1/2`) and added `min-h-0` flexbox fix
  - `modal.base.vue`: Refactored modal and backdrop into reusable CSS classes with responsive widths (`w-3/4` mobile → `sm:w-2/3` → `md:w-1/2` → `lg:w-1/3`)
  - `tabList.base.vue`: Added scroll wrapper with scrollbar styling and improved tab list layout using `w-max` and `min-w-full`
- **Provider Components:**
  - `toast.provider.vue`: Extracted toaster styles with mobile-first approach (`w-5/6` → `sm:w-3/5` → `lg:w-1/2` → `xl:w-1/3`)
- **Page Components:**
  - `login.page.vue`: Responsive login form (`w-[calc(100%-32px)]` → `sm:w-2/3` → `lg:w-1/2` → `xl:w-2/5` → `2xl:w-1/3`)
  - `matches.create.page.vue`: Responsive match creation form with same breakpoint strategy
  - `match.page.vue`: Updated spacing and layout direction (`gap-y-4` → `gap-4 sm:flex-row`)
- **Match Components:**
  - `matches.chatHistory.component.vue`: Responsive chat history container with improved width handling
  - `matches.drawer.component.vue`: Major refactor for mobile support including flexible header layout (`flex-col` → `md:flex-row`), responsive padding, and `BaseCaption` component usage for better text sizing
  - `matches.lobbyStatus.component.vue`: Complex grid restructuring for mobile (`grid-cols-[0.5rem_1fr_auto_auto]` mobile → `sm:grid-cols-[0.5rem_1fr_1fr_5rem_2em]`), added row-spanning for compact mobile display, and scrollable modifications container

## :ticket: Related Issue(s)

Closes: #157

## :clipboard: Checklist

- [x] I have performed a self-review of my code
- [x] If needed, I updated the documentation accordingly
- [x] For bug fixes or features, I added some tests
- [x] If I introduced a new server route. I updated [`allowedHttpMethodsOnResource`](https://github.com/kibotrel/osu-tournament-manager/blob/main/apps/server/src/constants/httpConstants.ts#L9) accordingly.