### PR TITLE
fix(packages/bancho-client/events): don't flag team color as mod in MultiplayerChannelInformationSlotEvent

### DIFF
--- a/packages/bancho-client/src/classes/ircCommandPrivateMessage.class.ts
+++ b/packages/bancho-client/src/classes/ircCommandPrivateMessage.class.ts
@@ -359,6 +359,11 @@ export class IrcCommandPrivateMessage implements IrcCommand {
   private handleMultiplayerChannelInformationSlotEvent(payload: Payload) {
     const { channel, message } = payload;
     const match = new RegExp(BanchoBotCommonMessage.MatchSlot).exec(message);
+    const nonDifficultyAttributes = new Set<string>([
+      BanchoTerm.Host,
+      BanchoTerm.TeamBlue,
+      BanchoTerm.TeamRed,
+    ]);
 
     if (!match) {
       return;
@@ -372,11 +377,11 @@ export class IrcCommandPrivateMessage implements IrcCommand {
       user,
     } = match.groups!;
     const modifications = attributes
-      .slice(attributes.indexOf('/') + 1)
+      .slice(attributes.lastIndexOf('/') + 1)
       .trim()
       .split(', ')
-      .filter((modification) => {
-        return modification !== BanchoTerm.Host;
+      .filter((attribute) => {
+        return !nonDifficultyAttributes.has(attribute);
       })
       .filter(Boolean);
     const data = {

--- a/packages/bancho-client/src/classes/ircCommandPrivateMessage.class.unit.test.ts
+++ b/packages/bancho-client/src/classes/ircCommandPrivateMessage.class.unit.test.ts
@@ -325,7 +325,7 @@ describe('IrcCommandPrivateMessage', () => {
     it('should also emit multiplayer_channel_information_slot event if sender is BanchoBot and received message containing slot information', () => {
       const packetParts = [
         'BanchoBot!server@localhost.dev PRIVMSG #channel',
-        'Slot 5 Not Ready https://osu.ppy.sh/u/123456 player1 [Host, Hidden]',
+        'Slot 5 Not Ready https://osu.ppy.sh/u/123456 player1 [Host / Team Blue / Hidden]',
       ];
       const command = new IrcCommandPrivateMessage(banchoClient, packetParts);
       const eventEmitter = vi.spyOn(banchoClient, 'emit');

--- a/packages/bancho-client/src/constants/banchoClient.constants.ts
+++ b/packages/bancho-client/src/constants/banchoClient.constants.ts
@@ -71,4 +71,6 @@ export enum BanchoReadyStatus {
 
 export enum BanchoTerm {
   Host = 'Host',
+  TeamBlue = 'Team Blue',
+  TeamRed = 'Team Red',
 }


### PR DESCRIPTION
## :book: Description

When using the refresh button in match drawer when match type was set to `Team VS`, team color appeared as mod. This PR fixes the issue.

**Changes:**
- Modified `packages/bancho-client` to fix team color parsing in `MultiplayerChannelInformationSlotEvent`
- Changed from using `indexOf('/')` to `lastIndexOf('/')` to correctly identify the last separator
- Added `nonDifficultyAttributes` Set to filter out team color attributes (`Team Blue`, `Team Red`) and `Host` status
- Updated test case to reflect the new slot format with team colors
- Added `TeamBlue` and `TeamRed` constants to `BanchoTerm` enum

## :ticket: Related Issue(s)

Closes: #159

## :clipboard: Checklist

- [x] I have performed a self-review of my code
- [x] If needed, I updated the documentation accordingly
- [x] For bug fixes or features, I added some tests
- [x] If I introduced a new server route. I updated [`allowedHttpMethodsOnResource`](https://github.com/kibotrel/osu-tournament-manager/blob/main/apps/server/src/constants/httpConstants.ts#L9) accordingly.